### PR TITLE
fix: pull changes from working branch

### DIFF
--- a/src/create-or-update-branch.ts
+++ b/src/create-or-update-branch.ts
@@ -195,7 +195,7 @@ export async function createOrUpdateBranch(
     await git.checkout(base)
     // Cherrypick commits from the temporary branch starting from the working base
     const commits = await git.revList(
-      [`${workingBase}..${tempBranch}`, '.'],
+      [`${base}..${tempBranch}`, '.'],
       ['--reverse']
     )
     for (const commit of splitLines(commits)) {


### PR DESCRIPTION
The temporary branch is created from the working base branch. So the differences between the two branches will always be none. What we want is all the differences from temporary branch to the base branch.